### PR TITLE
fix: resolve module aliases at runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ WORKDIR /app
 COPY --from=build /app/package*.json ./
 RUN npm ci --omit=dev
 COPY --from=build /app/dist ./dist
-CMD ["node", "dist/index.js"]
+CMD ["node", "-r", "module-alias/register", "dist/index.js"]

--- a/db/schema.sql
+++ b/db/schema.sql
@@ -1,0 +1,160 @@
+-- Database schema for taxi aggregation service
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+
+-- Users table
+CREATE TABLE IF NOT EXISTS public.users (
+  telegram_id BIGINT PRIMARY KEY,
+  phone TEXT,
+  first_name TEXT,
+  username TEXT,
+  role TEXT CHECK (role IN ('DRIVER','COURIER','CLIENT')),
+  verify_status TEXT CHECK (verify_status IN ('PENDING','APPROVED','REJECTED')),
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+ALTER TABLE public.users ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Users are self" ON public.users
+  FOR ALL
+  USING (telegram_id = (current_setting('request.jwt.claims', true)::jsonb->>'telegram_id')::bigint)
+  WITH CHECK (telegram_id = (current_setting('request.jwt.claims', true)::jsonb->>'telegram_id')::bigint);
+
+-- Profiles table
+CREATE TABLE IF NOT EXISTS public.profiles (
+  telegram_id BIGINT PRIMARY KEY REFERENCES public.users(telegram_id) ON DELETE CASCADE,
+  full_name TEXT,
+  phone TEXT,
+  car_model TEXT,
+  car_number TEXT,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+ALTER TABLE public.profiles ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Profiles are self" ON public.profiles
+  FOR ALL
+  USING (telegram_id = (current_setting('request.jwt.claims', true)::jsonb->>'telegram_id')::bigint)
+  WITH CHECK (telegram_id = (current_setting('request.jwt.claims', true)::jsonb->>'telegram_id')::bigint);
+
+-- App settings
+CREATE TABLE IF NOT EXISTS public.app_settings (
+  key TEXT PRIMARY KEY,
+  value TEXT
+);
+
+ALTER TABLE public.app_settings ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Public read app settings" ON public.app_settings
+  FOR SELECT
+  USING (((current_setting('request.jwt.claims', true)::jsonb->>'telegram_id')::bigint IS NOT NULL));
+
+-- Verifications
+CREATE TABLE IF NOT EXISTS public.verifications (
+  telegram_id BIGINT PRIMARY KEY REFERENCES public.users(telegram_id) ON DELETE CASCADE,
+  role TEXT CHECK (role IN ('DRIVER','COURIER','CLIENT')),
+  status TEXT CHECK (status IN ('PENDING','APPROVED','REJECTED')),
+  reason TEXT,
+  files JSONB,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+ALTER TABLE public.verifications ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Verifications are self" ON public.verifications
+  FOR ALL
+  USING (telegram_id = (current_setting('request.jwt.claims', true)::jsonb->>'telegram_id')::bigint)
+  WITH CHECK (telegram_id = (current_setting('request.jwt.claims', true)::jsonb->>'telegram_id')::bigint);
+
+-- Subscriptions
+CREATE TABLE IF NOT EXISTS public.subscriptions (
+  telegram_id BIGINT PRIMARY KEY REFERENCES public.users(telegram_id) ON DELETE CASCADE,
+  until_ts TIMESTAMPTZ NOT NULL,
+  plan_days INTEGER NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+ALTER TABLE public.subscriptions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Subscriptions are self" ON public.subscriptions
+  FOR ALL
+  USING (telegram_id = (current_setting('request.jwt.claims', true)::jsonb->>'telegram_id')::bigint)
+  WITH CHECK (telegram_id = (current_setting('request.jwt.claims', true)::jsonb->>'telegram_id')::bigint);
+
+-- Receipts
+CREATE TABLE IF NOT EXISTS public.receipts (
+  id BIGSERIAL PRIMARY KEY,
+  telegram_id BIGINT NOT NULL REFERENCES public.users(telegram_id) ON DELETE CASCADE,
+  plan_days INTEGER NOT NULL,
+  file JSONB,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+ALTER TABLE public.receipts ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Receipts are self" ON public.receipts
+  FOR ALL
+  USING (telegram_id = (current_setting('request.jwt.claims', true)::jsonb->>'telegram_id')::bigint)
+  WITH CHECK (telegram_id = (current_setting('request.jwt.claims', true)::jsonb->>'telegram_id')::bigint);
+
+-- Orders
+CREATE TABLE IF NOT EXISTS public.orders (
+  id BIGSERIAL PRIMARY KEY,
+  client_id BIGINT NOT NULL REFERENCES public.users(telegram_id) ON DELETE CASCADE,
+  driver_id BIGINT REFERENCES public.users(telegram_id) ON DELETE SET NULL,
+  kind TEXT CHECK (kind IN ('TAXI','DELIVERY')),
+  from_text TEXT,
+  from_lat DOUBLE PRECISION,
+  from_lon DOUBLE PRECISION,
+  to_text TEXT,
+  to_lat DOUBLE PRECISION,
+  to_lon DOUBLE PRECISION,
+  comment_text TEXT,
+  price_estimate NUMERIC,
+  status TEXT CHECK (status IN ('NEW','TAKEN','CANCELLED','DONE')) DEFAULT 'NEW',
+  channel_msg_id BIGINT,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+ALTER TABLE public.orders ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Orders visible to client or driver" ON public.orders
+  FOR SELECT
+  USING (
+    client_id = (current_setting('request.jwt.claims', true)::jsonb->>'telegram_id')::bigint
+    OR driver_id = (current_setting('request.jwt.claims', true)::jsonb->>'telegram_id')::bigint
+  );
+
+CREATE POLICY "Clients manage their orders" ON public.orders
+  FOR INSERT
+  WITH CHECK (client_id = (current_setting('request.jwt.claims', true)::jsonb->>'telegram_id')::bigint);
+
+CREATE POLICY "Client or driver update own order" ON public.orders
+  FOR UPDATE
+  USING (
+    client_id = (current_setting('request.jwt.claims', true)::jsonb->>'telegram_id')::bigint
+    OR driver_id = (current_setting('request.jwt.claims', true)::jsonb->>'telegram_id')::bigint
+  )
+  WITH CHECK (
+    client_id = (current_setting('request.jwt.claims', true)::jsonb->>'telegram_id')::bigint
+    OR driver_id = (current_setting('request.jwt.claims', true)::jsonb->>'telegram_id')::bigint
+  );
+
+-- Media assets
+CREATE TABLE IF NOT EXISTS public.media_assets (
+  id BIGSERIAL PRIMARY KEY,
+  owner_telegram_id BIGINT NOT NULL REFERENCES public.users(telegram_id) ON DELETE CASCADE,
+  kind TEXT NOT NULL,
+  file_path TEXT NOT NULL,
+  file_url TEXT,
+  mime TEXT,
+  meta JSONB,
+  created_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+ALTER TABLE public.media_assets ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Media assets are self" ON public.media_assets
+  FOR ALL
+  USING (owner_telegram_id = (current_setting('request.jwt.claims', true)::jsonb->>'telegram_id')::bigint)
+  WITH CHECK (owner_telegram_id = (current_setting('request.jwt.claims', true)::jsonb->>'telegram_id')::bigint);

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@supabase/supabase-js": "^2.57.4",
         "dotenv": "^17.2.2",
         "express": "^5.1.0",
+        "module-alias": "^2.2.3",
         "node-fetch": "^3.3.2",
         "pdfkit": "^0.17.2",
         "telegraf": "^4.16.3",
@@ -23,6 +24,7 @@
         "@types/pdfkit": "^0.17.3",
         "ts-node": "^10.9.2",
         "ts-node-dev": "^2.0.0",
+        "tsconfig-paths": "^4.2.0",
         "typegram": "^5.2.0",
         "typescript": "^5.9.2"
       },
@@ -1239,6 +1241,19 @@
       "integrity": "sha512-a+bKEcCjtuW5WTdgeXFzswSrdqi0jk4XlEtZlx5A94wCoBpFjfFTbo/Tra5SpNCl/YFZPvcV1dJc+TAYeg6ROQ==",
       "license": "MIT"
     },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/linebreak": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/linebreak/-/linebreak-1.1.0.tgz",
@@ -1351,6 +1366,12 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/module-alias": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/module-alias/-/module-alias-2.2.3.tgz",
+      "integrity": "sha512-23g5BFj4zdQL/b6tor7Ji+QY4pEfNH784BMslY9Qb0UnJWRAt+lQGLYmRaM0KDBwIG23ffEBELhZDP2rhi9f/Q==",
+      "license": "MIT"
     },
     "node_modules/mri": {
       "version": "1.2.0",
@@ -2075,6 +2096,21 @@
         "@types/strip-json-comments": "0.0.30",
         "strip-bom": "^3.0.0",
         "strip-json-comments": "^2.0.0"
+      }
+    },
+    "node_modules/tsconfig-paths": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.2.0.tgz",
+      "integrity": "sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json5": "^2.2.2",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/tslib": {

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "tsc -p tsconfig.json",
-    "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
-    "start": "node dist/index.js"
+    "dev": "ts-node-dev -r tsconfig-paths/register --respawn --transpile-only src/index.ts",
+    "start": "node -r module-alias/register dist/index.js"
   },
   "keywords": [],
   "author": "",
@@ -20,7 +20,8 @@
     "node-fetch": "^3.3.2",
     "pdfkit": "^0.17.2",
     "telegraf": "^4.16.3",
-    "zod": "^4.1.5"
+    "zod": "^4.1.5",
+    "module-alias": "^2.2.3"
   },
   "devDependencies": {
     "@types/express": "^5.0.3",
@@ -28,8 +29,12 @@
     "@types/pdfkit": "^0.17.3",
     "ts-node": "^10.9.2",
     "ts-node-dev": "^2.0.0",
+    "tsconfig-paths": "^4.2.0",
     "typegram": "^5.2.0",
     "typescript": "^5.9.2"
+  },
+  "_moduleAliases": {
+    "@": "dist"
   },
   "engines": {
     "node": ">=20"

--- a/src/modules/roles.ts
+++ b/src/modules/roles.ts
@@ -1,6 +1,7 @@
 import { Telegraf, type Context, Markup } from 'telegraf';
 import { ensureUserFromCtx } from '@/supabase';
 import type { Role } from '@/types';
+import { showHome } from './home';
 
 export function register(bot: Telegraf<Context>) {
   bot.command('role', async (ctx: Context) => {
@@ -24,17 +25,20 @@ export function register(bot: Telegraf<Context>) {
 
     await ensureUserFromCtx(ctx, { role });
 
-    await ctx.editMessageText(
+    await ctx.deleteMessage();
+    await ctx.reply(
       `Роль установлена: ${role === 'DRIVER' ? 'Водитель' : role === 'COURIER' ? 'Курьер' : 'Клиент'}`
     );
 
     if (role === 'DRIVER' || role === 'COURIER') {
       await ctx.reply(
-        'Для доступа к заказам пройдите проверку:',
-        Markup.inlineKeyboard([
-          [Markup.button.callback('✅ Пройти проверку', 'go_verify')]
-        ])
+        'Поделитесь контактом, чтобы получать заказы:',
+        Markup.keyboard([[Markup.button.contactRequest('📱 Поделиться контактом')]])
+          .oneTime()
+          .resize()
       );
+    } else {
+      await showHome(ctx);
     }
   });
 }


### PR DESCRIPTION
## Summary
- add database schema with tables and RLS policies
- resolve `@` module alias at runtime via module-alias to fix container startup
- ensure schema uses `IF NOT EXISTS` and include `pgcrypto` extension
- prompt drivers and couriers to share contact number after role selection
- keep module-alias dependency in lockfile

## Testing
- `npm run build`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c1cf5f5314832db1d09e41b931acef