### PR TITLE
Handle admin binding commands in channels

### DIFF
--- a/src/modules/admin.ts
+++ b/src/modules/admin.ts
@@ -2,20 +2,34 @@ import { Telegraf, type Context } from 'telegraf';
 import { setSetting } from '@/supabase';
 
 export function register(bot: Telegraf<Context>) {
-  bot.command('bind_verify_channel', async (ctx: Context) => {
+  const bindVerify = async (ctx: Context) => {
     const id = ctx.chat?.id;
     if (!id || id > 0)
       return ctx.reply('Команду запускают в КАНАЛЕ/ГРУППЕ модерации.');
     await setSetting('verify_channel_id', String(id));
+    await setSetting('bindings_updated_at', new Date().toISOString());
     await ctx.reply('Канал модерации привязан.');
-  });
+  };
 
-  bot.command('bind_drivers_channel', async (ctx: Context) => {
+  const bindDrivers = async (ctx: Context) => {
     const id = ctx.chat?.id;
     if (!id || id > 0)
       return ctx.reply('Команду запускают в КАНАЛЕ/ГРУППЕ водителей.');
     await setSetting('drivers_channel_id', String(id));
+    await setSetting('bindings_updated_at', new Date().toISOString());
     await ctx.reply('Канал водителей привязан.');
+  };
+
+  bot.command('bind_verify_channel', bindVerify);
+  bot.command('bind_drivers_channel', bindDrivers);
+
+  // Telegraf не обрабатывает команды внутри каналов по умолчанию,
+  // поэтому перехватываем channel_post и выполняем нужный обработчик вручную
+  bot.on('channel_post', async (ctx) => {
+    const text = ctx.channelPost?.text;
+    if (!text) return;
+    if (text.startsWith('/bind_verify_channel')) return bindVerify(ctx as any);
+    if (text.startsWith('/bind_drivers_channel')) return bindDrivers(ctx as any);
   });
 
   bot.command('set_invite', async (ctx: Context) => {

--- a/src/modules/admin.ts
+++ b/src/modules/admin.ts
@@ -26,8 +26,9 @@ export function register(bot: Telegraf<Context>) {
   // Telegraf не обрабатывает команды внутри каналов по умолчанию,
   // поэтому перехватываем channel_post и выполняем нужный обработчик вручную
   bot.on('channel_post', async (ctx) => {
-    const text = ctx.channelPost?.text;
-    if (!text) return;
+    const post = ctx.channelPost;
+    if (!post || !('text' in post)) return;
+    const text = post.text;
     if (text.startsWith('/bind_verify_channel')) return bindVerify(ctx as any);
     if (text.startsWith('/bind_drivers_channel')) return bindDrivers(ctx as any);
   });


### PR DESCRIPTION
## Summary
- ensure admin binding commands work when run from channels
- track binding updates timestamp

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c1f6205db8832da98590752df9f852